### PR TITLE
Replace svelte-french-toast with svelte-sonner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"rollup-plugin-visualizer": "^6.0.3",
 				"svelte": "^5.36.8",
 				"svelte-check": "^4.3.0",
-				"svelte-french-toast": "^1.2.0",
+				"svelte-sonner": "^1.0.5",
 				"tar-stream": "^3.1.7",
 				"typescript": "^5.8.3",
 				"typescript-eslint": "^8.37.0",
@@ -5617,6 +5617,23 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/runed": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/runed/-/runed-0.28.0.tgz",
+			"integrity": "sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/huntabyte",
+				"https://github.com/sponsors/tglide"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"esm-env": "^1.0.0"
+			},
+			"peerDependencies": {
+				"svelte": "^5.7.0"
+			}
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -6124,30 +6141,17 @@
 				}
 			}
 		},
-		"node_modules/svelte-french-toast": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/svelte-french-toast/-/svelte-french-toast-1.2.0.tgz",
-			"integrity": "sha512-5PW+6RFX3xQPbR44CngYAP1Sd9oCq9P2FOox4FZffzJuZI2mHOB7q5gJBVnOiLF5y3moVGZ7u2bYt7+yPAgcEQ==",
+		"node_modules/svelte-sonner": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/svelte-sonner/-/svelte-sonner-1.0.5.tgz",
+			"integrity": "sha512-9dpGPFqKb/QWudYqGnEz93vuY+NgCEvyNvxoCLMVGw6sDN/3oVeKV1xiEirW2E1N3vJEyj5imSBNOGltQHA7mg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"svelte-writable-derived": "^3.1.0"
+				"runed": "^0.28.0"
 			},
 			"peerDependencies": {
-				"svelte": "^3.57.0 || ^4.0.0"
-			}
-		},
-		"node_modules/svelte-writable-derived": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/svelte-writable-derived/-/svelte-writable-derived-3.1.1.tgz",
-			"integrity": "sha512-w4LR6/bYZEuCs7SGr+M54oipk/UQKtiMadyOhW0PTwAtJ/Ai12QS77sLngEcfBx2q4H8ZBQucc9ktSA5sUGZWw==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://ko-fi.com/pixievoltno1"
-			},
-			"peerDependencies": {
-				"svelte": "^3.2.1 || ^4.0.0-next.1 || ^5.0.0-next.94"
+				"svelte": "^5.0.0"
 			}
 		},
 		"node_modules/svelte/node_modules/is-reference": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"rollup-plugin-visualizer": "^6.0.3",
 		"svelte": "^5.36.8",
 		"svelte-check": "^4.3.0",
-		"svelte-french-toast": "^1.2.0",
+		"svelte-sonner": "^1.0.5",
 		"tar-stream": "^3.1.7",
 		"typescript": "^5.8.3",
 		"typescript-eslint": "^8.37.0",
@@ -52,10 +52,5 @@
 		"vitest": "^3.2.4",
 		"zod": "^3.25.76"
 	},
-	"type": "module",
-	"overrides": {
-		"svelte-french-toast": {
-			"svelte": "^5.0.0"
-		}
-	}
+	"type": "module"
 }

--- a/src/lib/components/PresetListItem.svelte
+++ b/src/lib/components/PresetListItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte'
-	import toast from 'svelte-french-toast'
+	import { toast } from 'svelte-sonner'
 	import CopyIcon from './CopyIcon.svelte'
 	import DownloadIcon from './DownloadIcon.svelte'
 

--- a/src/lib/components/mcp/McpCodeBlock.svelte
+++ b/src/lib/components/mcp/McpCodeBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import CopyIcon from '$lib/components/CopyIcon.svelte'
-	import toast from 'svelte-french-toast'
+	import { toast } from 'svelte-sonner'
 
 	let {
 		code,

--- a/src/lib/components/mcp/McpUrlBlock.svelte
+++ b/src/lib/components/mcp/McpUrlBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import CopyIcon from '$lib/components/CopyIcon.svelte'
-	import toast from 'svelte-french-toast'
+	import { toast } from 'svelte-sonner'
 
 	let {
 		label,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { SITE_URL } from '$lib/constants'
-	import { Toaster } from 'svelte-french-toast'
+	import { Toaster } from 'svelte-sonner'
 
 	let { children } = $props()
 


### PR DESCRIPTION
Swapped out the svelte-french-toast notification library for svelte-sonner across the codebase. Updated all relevant imports and usage in Svelte components and adjusted dependencies in package.json and package-lock.json accordingly.