### PR TITLE
Revert MCP adapter override and add memory monitoring tools

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,12 +28,6 @@ export default [
 		}
 	},
 	{
-		rules: {
-			'@typescript-eslint/no-explicit-any': 'off',
-			'@typescript-eslint/no-unused-vars': 'off'
-		}
-	},
-	{
-		ignores: ['build/', '.svelte-kit/', 'dist/', 'node_modules/']
+		ignores: ['build/', '.svelte-kit/', 'dist/']
 	}
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"eslint-plugin-svelte": "^3.11.0",
 				"globals": "^16.3.0",
 				"jsdom": "^26.1.0",
-				"mcp-handler": "^1.0.1",
+				"mcp-handler": "^0.0.0-1c08e814-20250813181123",
 				"minimatch": "^10.0.3",
 				"pg": "^8.16.3",
 				"postgres-migrations": "https://github.com/khromov/postgres-migrations",
@@ -4390,9 +4390,9 @@
 			}
 		},
 		"node_modules/mcp-handler": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.0.1.tgz",
-			"integrity": "sha512-a4AB6eI8XdBrL9LYS68XLflh48lJI+nNPEPVj1FMI7CXZIsj/jOx4PbCeiWqrBJf2QRoCT1rxSXI8cN4AsdS4w==",
+			"version": "0.0.0-1c08e814-20250813181123",
+			"resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-0.0.0-1c08e814-20250813181123.tgz",
+			"integrity": "sha512-zzScsMkCt3TKe5g1on6yiTFwDmK/NgCl+EMh5/g4Ca+zLmeUQwt8gA6/80ZxQoBgUF/gi+5NuNuX9QIOOET49A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"eslint-plugin-svelte": "^3.11.0",
 				"globals": "^16.3.0",
 				"jsdom": "^26.1.0",
-				"mcp-handler": "https://github.com/vercel/mcp-adapter/tarball/potential",
+				"mcp-handler": "^1.0.1",
 				"minimatch": "^10.0.3",
 				"pg": "^8.16.3",
 				"postgres-migrations": "https://github.com/khromov/postgres-migrations",
@@ -4391,8 +4391,8 @@
 		},
 		"node_modules/mcp-handler": {
 			"version": "1.0.1",
-			"resolved": "https://github.com/vercel/mcp-adapter/tarball/potential",
-			"integrity": "sha512-5LIHWguYCmRQI8zfcMKuy/c6kassEuT0XJL5AiJxUYrBnnIV/XlSW2WzX4F8Ga35jM/Hqyw9qIPnCBetITgIIg==",
+			"resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.0.1.tgz",
+			"integrity": "sha512-a4AB6eI8XdBrL9LYS68XLflh48lJI+nNPEPVj1FMI7CXZIsj/jOx4PbCeiWqrBJf2QRoCT1rxSXI8cN4AsdS4w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"eslint-plugin-svelte": "^3.11.0",
 		"globals": "^16.3.0",
 		"jsdom": "^26.1.0",
-		"mcp-handler": "^1.0.1",
+		"mcp-handler": "^0.0.0-1c08e814-20250813181123",
 		"minimatch": "^10.0.3",
 		"pg": "^8.16.3",
 		"postgres-migrations": "https://github.com/khromov/postgres-migrations",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"eslint-plugin-svelte": "^3.11.0",
 		"globals": "^16.3.0",
 		"jsdom": "^26.1.0",
-		"mcp-handler": "https://github.com/vercel/mcp-adapter/tarball/potential",
+		"mcp-handler": "^1.0.1",
 		"minimatch": "^10.0.3",
 		"pg": "^8.16.3",
 		"postgres-migrations": "https://github.com/khromov/postgres-migrations",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"mcp": "DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector",
 		"clear-db": "node scripts/clear-db.js",
 		"bp": "npm run build && CONTENT_SYNC_SECRET_KEY=secret DEV=true node --expose-gc build/ ",
+		"bp-snapshot": "mkdir -p mount && curl 'http://localhost:3000/api/heap-snapshot?secret_key=secret'",
 		"stress-test": "node --expose-gc scripts/test-client-stress.mjs http://localhost:3000"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 		"test:unit": "vitest",
 		"test": "npm run test:unit -- --run",
 		"mcp": "DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector",
-		"clear-db": "node scripts/clear-db.js"
+		"clear-db": "node scripts/clear-db.js",
+		"bp": "npm run build && CONTENT_SYNC_SECRET_KEY=secret DEV=true node --expose-gc build/ ",
+		"stress-test": "node --expose-gc scripts/test-client-stress.mjs http://localhost:3000"
 	},
 	"devDependencies": {
 		"@anthropic-ai/sdk": "^0.57.0",

--- a/scripts/test-client-stress.mjs
+++ b/scripts/test-client-stress.mjs
@@ -1,0 +1,324 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+
+const origin = process.argv[2] || 'http://localhost:3000'
+const SESSION_COUNT = parseInt(process.argv[3]) || 10000
+const BATCH_SIZE = 100
+
+// Parse command line flags
+const args = process.argv.slice(2)
+const enableMemoryMonitoring = args.includes('--memory')
+const triggerSnapshot = args.includes('--snapshot')
+const secretKeyIndex = args.indexOf('--secret-key')
+const secretKey =
+	secretKeyIndex !== -1 && secretKeyIndex + 1 < args.length ? args[secretKeyIndex + 1] : 'secret'
+
+if (triggerSnapshot && !secretKey) {
+	console.error('❌ --secret-key is required when using --snapshot flag')
+	process.exit(1)
+}
+
+async function getMemoryStatus(origin) {
+	try {
+		const url = new URL('/api/memory-status', origin)
+
+		const response = await fetch(url)
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+		}
+
+		return await response.json()
+	} catch (error) {
+		console.warn(`⚠️  Failed to get memory status: ${error.message}`)
+		return null
+	}
+}
+
+async function triggerHeapSnapshot(origin, secretKey) {
+	try {
+		const url = new URL('/api/heap-snapshot', origin)
+		url.searchParams.set('secret_key', secretKey)
+
+		const response = await fetch(url)
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+		}
+
+		return await response.json()
+	} catch (error) {
+		console.warn(`⚠️  Failed to trigger heap snapshot: ${error.message}`)
+		return null
+	}
+}
+
+function formatBytes(bytes) {
+	if (bytes === 0) return '0 B'
+	const k = 1024
+	const sizes = ['B', 'KB', 'MB', 'GB']
+	const i = Math.floor(Math.log(bytes) / Math.log(k))
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+function displayMemoryStatus(status, label) {
+	if (!status) return
+
+	const mem = status.process.memory
+	console.log(`\n💾 ${label}:`)
+	console.log(`  Heap Used: ${mem.heapUsedFormatted} (${mem.heapUsagePercentage}%)`)
+	console.log(`  Heap Total: ${mem.heapTotalFormatted}`)
+	console.log(`  RSS: ${mem.rssFormatted}`)
+	console.log(`  External: ${mem.externalFormatted}`)
+
+	if (status.system) {
+		console.log(
+			`  System Free: ${status.system.freeFormatted} (${(100 - parseFloat(status.system.usedPercentage)).toFixed(1)}%)`
+		)
+	}
+}
+
+async function createSession(id, origin) {
+	const startTime = Date.now()
+	try {
+		const transport = new SSEClientTransport(new URL(`${origin}/mcp/sse`))
+
+		const client = new Client(
+			{
+				name: `stress-test-client-${id}`,
+				version: '1.0.0'
+			},
+			{
+				capabilities: {
+					prompts: {},
+					resources: {},
+					tools: {}
+				}
+			}
+		)
+
+		await client.connect(transport)
+		const connectTime = Date.now() - startTime
+
+		const capabilities = client.getServerCapabilities()
+		const tools = await client.listTools()
+
+		// Call the list_sections tool to test functionality
+		let sectionsResult = null
+		try {
+			const sectionsResponse = await client.callTool({
+				name: 'list_sections',
+				arguments: {}
+			})
+			const sectionsText = sectionsResponse.content?.[0]?.text || 'No response'
+			// Count the number of sections in the response
+			const sectionCount = (sectionsText.match(/\* title:/g) || []).length
+			sectionsResult = `Found ${sectionCount} documentation sections`
+		} catch (error) {
+			sectionsResult = `List sections failed: ${error.message}`
+		}
+
+		return {
+			id,
+			status: 'connected',
+			connectTime,
+			toolCount: tools.tools?.length || 0,
+			sectionsResult,
+			client
+		}
+	} catch (error) {
+		return {
+			id,
+			status: 'failed',
+			error: error.message,
+			connectTime: Date.now() - startTime
+		}
+	}
+}
+
+async function runStressTest() {
+	console.log(`🚀 Starting stress test with ${SESSION_COUNT} sessions to ${origin}`)
+	console.log(`Batching ${BATCH_SIZE} connections at a time...`)
+
+	if (enableMemoryMonitoring) {
+		console.log(`💾 Memory monitoring enabled`)
+	}
+	if (triggerSnapshot) {
+		console.log(`📸 Heap snapshot will be triggered at completion`)
+	}
+	console.log()
+
+	// Get initial memory baseline if monitoring is enabled
+	let initialMemory = null
+	if (enableMemoryMonitoring) {
+		initialMemory = await getMemoryStatus(origin)
+		displayMemoryStatus(initialMemory, 'Initial Memory Status')
+	}
+
+	const results = []
+	const startTime = Date.now()
+
+	for (let i = 0; i < SESSION_COUNT; i += BATCH_SIZE) {
+		const batchStart = i
+		const batchEnd = Math.min(i + BATCH_SIZE, SESSION_COUNT)
+		const batchSize = batchEnd - batchStart
+
+		console.log(
+			`Starting batch ${Math.floor(i / BATCH_SIZE) + 1}: sessions ${batchStart + 1}-${batchEnd}`
+		)
+
+		const batchPromises = []
+		for (let j = batchStart; j < batchEnd; j++) {
+			batchPromises.push(createSession(j + 1, origin))
+		}
+
+		const batchResults = await Promise.all(batchPromises)
+		results.push(...batchResults)
+
+		const connected = batchResults.filter((r) => r.status === 'connected').length
+		const failed = batchResults.filter((r) => r.status === 'failed').length
+		console.log(`  ✓ Batch complete: ${connected} connected, ${failed} failed`)
+	}
+
+	// Get peak memory usage after all connections are established
+	let peakMemory = null
+	if (enableMemoryMonitoring) {
+		peakMemory = await getMemoryStatus(origin)
+		displayMemoryStatus(peakMemory, 'Peak Memory Status (All Connections Active)')
+	}
+
+	const totalTime = Date.now() - startTime
+
+	const connected = results.filter((r) => r.status === 'connected')
+	const failed = results.filter((r) => r.status === 'failed')
+
+	console.log('\n📊 STRESS TEST RESULTS')
+	console.log('══════════════════════')
+	console.log(`Total Sessions: ${SESSION_COUNT}`)
+	console.log(
+		`✅ Connected: ${connected.length} (${((connected.length / SESSION_COUNT) * 100).toFixed(1)}%)`
+	)
+	console.log(
+		`❌ Failed: ${failed.length} (${((failed.length / SESSION_COUNT) * 100).toFixed(1)}%)`
+	)
+	console.log(`⏱️  Total Time: ${(totalTime / 1000).toFixed(2)}s`)
+
+	// Add memory summary if monitoring was enabled
+	if (enableMemoryMonitoring && initialMemory && peakMemory) {
+		const initialHeap = initialMemory.process.memory.heapUsed
+		const peakHeap = peakMemory.process.memory.heapUsed
+		const heapGrowth = peakHeap - initialHeap
+
+		console.log(
+			`💾 Memory Usage: ${formatBytes(initialHeap)} → ${formatBytes(peakHeap)} (+${formatBytes(heapGrowth)})`
+		)
+	}
+
+	if (connected.length > 0) {
+		const avgConnectTime = connected.reduce((acc, r) => acc + r.connectTime, 0) / connected.length
+		const minConnectTime = Math.min(...connected.map((r) => r.connectTime))
+		const maxConnectTime = Math.max(...connected.map((r) => r.connectTime))
+
+		console.log('\n⚡ Connection Times:')
+		console.log(`  Average: ${avgConnectTime.toFixed(0)}ms`)
+		console.log(`  Min: ${minConnectTime}ms`)
+		console.log(`  Max: ${maxConnectTime}ms`)
+
+		const toolCounts = [...new Set(connected.map((r) => r.toolCount))]
+		if (toolCounts.length === 1) {
+			console.log(`\n🔧 Tools Available: ${toolCounts[0]}`)
+		} else {
+			console.log(`\n🔧 Tools Available: varies (${toolCounts.join(', ')})`)
+		}
+
+		// Show list_sections test results
+		const sectionsSuccesses = connected.filter(
+			(r) => r.sectionsResult && !r.sectionsResult.startsWith('List sections failed')
+		).length
+		console.log(`\n📚 List Sections Tool Tests:`)
+		console.log(`  Successful: ${sectionsSuccesses}/${connected.length}`)
+		if (sectionsSuccesses < connected.length) {
+			const sampleFailure = connected.find((r) =>
+				r.sectionsResult?.startsWith('List sections failed')
+			)
+			if (sampleFailure) {
+				console.log(`  Sample failure: ${sampleFailure.sectionsResult}`)
+			}
+		}
+	}
+
+	if (failed.length > 0) {
+		console.log('\n⚠️  Failed Sessions:')
+		const errorTypes = {}
+		failed.forEach((r) => {
+			errorTypes[r.error] = (errorTypes[r.error] || 0) + 1
+		})
+		Object.entries(errorTypes).forEach(([error, count]) => {
+			console.log(`  ${count}x: ${error}`)
+		})
+	}
+
+	console.log('\n🧹 Cleaning up connections...')
+	let closeCount = 0
+	for (const result of connected) {
+		try {
+			await result.client.close()
+			closeCount++
+			if (closeCount % 20 === 0) {
+				process.stdout.write(`  Closed ${closeCount}/${connected.length} sessions\r`)
+			}
+		} catch {
+			// Ignore connection close errors
+		}
+	}
+	console.log(`  ✓ Closed ${closeCount}/${connected.length} sessions    `)
+
+	// Get final memory status after cleanup
+	let finalMemory = null
+	if (enableMemoryMonitoring) {
+		finalMemory = await getMemoryStatus(origin)
+		displayMemoryStatus(finalMemory, 'Final Memory Status (After Cleanup)')
+
+		// Display memory analysis
+		if (initialMemory && peakMemory && finalMemory) {
+			console.log('\n📈 MEMORY ANALYSIS')
+			console.log('══════════════════')
+
+			const initialHeap = initialMemory.process.memory.heapUsed
+			const peakHeap = peakMemory.process.memory.heapUsed
+			const finalHeap = finalMemory.process.memory.heapUsed
+
+			const heapGrowth = peakHeap - initialHeap
+			const heapLeak = finalHeap - initialHeap
+
+			console.log(`Initial Heap: ${formatBytes(initialHeap)}`)
+			console.log(`Peak Heap: ${formatBytes(peakHeap)} (+${formatBytes(heapGrowth)})`)
+			console.log(
+				`Final Heap: ${formatBytes(finalHeap)} (${heapLeak >= 0 ? '+' : ''}${formatBytes(heapLeak)})`
+			)
+
+			if (heapLeak > heapGrowth * 0.1) {
+				console.log(`⚠️  Potential memory leak detected: ${formatBytes(heapLeak)} not freed`)
+			} else {
+				console.log(`✅ Memory cleanup looks good`)
+			}
+		}
+	}
+
+	// Trigger heap snapshot if requested
+	if (triggerSnapshot) {
+		console.log('\n📸 Triggering heap snapshot...')
+		const snapshot = await triggerHeapSnapshot(origin, secretKey)
+		if (snapshot) {
+			console.log(`✅ Heap snapshot created: ${snapshot.snapshot.filename}`)
+			console.log(`   Size: ${snapshot.snapshot.sizeFormatted}`)
+			console.log(`   Path: ${snapshot.snapshot.path}`)
+		}
+	}
+
+	console.log('\n✨ Stress test complete!')
+	process.exit(failed.length > SESSION_COUNT * 0.1 ? 1 : 0)
+}
+
+runStressTest().catch((error) => {
+	console.error('Fatal error:', error)
+	process.exit(1)
+})

--- a/src/lib/mcpHandler.ts
+++ b/src/lib/mcpHandler.ts
@@ -46,7 +46,7 @@ export const handler = createMcpHandler(
 			'list_sections',
 			'Lists all available Svelte 5 and SvelteKit documentation sections in a structured format. Returns sections as a list of "* title: [section_title], path: [file_path]" - you can use either the title or path when querying a specific section via the get_documentation tool. Always run list_sections first for any query related to Svelte development to discover available content.',
 			{},
-			async () => listSectionsHandler()
+			listSectionsHandler
 		)
 
 		server.tool(
@@ -59,7 +59,7 @@ export const handler = createMcpHandler(
 						'The section name(s) to retrieve. Can search by title (e.g., "$state", "load functions") or file path (e.g., "docs/svelte/state.md"). Supports single string and array of strings'
 					)
 			},
-			async ({ section }) => getDocumentationHandler({ section })
+			getDocumentationHandler
 		)
 
 		// Main developer prompt with optional task parameter

--- a/src/lib/mcpHandler.ts
+++ b/src/lib/mcpHandler.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
-import createMcpHandler from '../../node_modules/mcp-handler/src/handler/index'
+import { createMcpHandler } from 'mcp-handler'
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { env } from '$env/dynamic/private'
 import { ContentDbService } from '$lib/server/contentDb'
 import { ContentDistilledDbService } from '$lib/server/contentDistilledDb'
@@ -42,7 +41,7 @@ function getTitleFromMetadata(
 }
 
 export const handler = createMcpHandler(
-	(server: McpServer) => {
+	(server) => {
 		server.tool(
 			'list_sections',
 			'Lists all available Svelte 5 and SvelteKit documentation sections in a structured format. Returns sections as a list of "* title: [section_title], path: [file_path]" - you can use either the title or path when querying a specific section via the get_documentation tool. Always run list_sections first for any query related to Svelte development to discover available content.',
@@ -60,7 +59,7 @@ export const handler = createMcpHandler(
 						'The section name(s) to retrieve. Can search by title (e.g., "$state", "load functions") or file path (e.g., "docs/svelte/state.md"). Supports single string and array of strings'
 					)
 			},
-			async ({ section }: { section: string | string[] }) => getDocumentationHandler({ section })
+			async ({ section }) => getDocumentationHandler({ section })
 		)
 
 		// Main developer prompt with optional task parameter
@@ -74,7 +73,7 @@ export const handler = createMcpHandler(
 					task: z.string().optional().describe('Optional specific task or requirement to focus on')
 				}
 			},
-			({ task }: { task?: string }) => {
+			({ task }) => {
 				const promptText = createSvelteDeveloperPromptWithTask(task)
 
 				return {
@@ -137,7 +136,7 @@ export const handler = createMcpHandler(
 					return { resources }
 				},
 				complete: {
-					slug: async (query: any) => {
+					slug: async (query) => {
 						const suggestions = []
 
 						// Add preset completions first
@@ -162,8 +161,7 @@ export const handler = createMcpHandler(
 					}
 				}
 			}),
-			async (uri: any, variables: any) => {
-				const slug = variables.slug
+			async (uri, { slug }) => {
 				// If array for some reason, use the first element
 				const slugString = Array.isArray(slug) ? slug[0] : slug
 

--- a/src/lib/presetCache.ts
+++ b/src/lib/presetCache.ts
@@ -27,7 +27,7 @@ export async function getPresetContent(presetKey: string): Promise<string | null
 		// Check cache first
 		const cache = getCacheService()
 		const cacheKey = `preset:${presetKey}`
-		
+
 		try {
 			const cachedData = await cache.get(cacheKey)
 			if (cachedData) {
@@ -175,11 +175,11 @@ export async function clearPresetCache(presetKey: string): Promise<boolean> {
 		const cache = getCacheService()
 		const cacheKey = `preset:${presetKey}`
 		const success = await cache.delete(cacheKey)
-		
+
 		if (success) {
 			logAlways(`Cleared cache for preset ${presetKey}`)
 		}
-		
+
 		return success
 	} catch (error) {
 		logErrorAlways(`Error clearing cache for preset ${presetKey}:`, error)
@@ -195,7 +195,7 @@ export async function clearAllPresetCaches(): Promise<number> {
 		const cache = getCacheService()
 		const allPresetKeys = Object.keys(presets)
 		let clearedCount = 0
-		
+
 		for (const presetKey of allPresetKeys) {
 			const cacheKey = `preset:${presetKey}`
 			const success = await cache.delete(cacheKey)
@@ -203,7 +203,7 @@ export async function clearAllPresetCaches(): Promise<number> {
 				clearedCount++
 			}
 		}
-		
+
 		logAlways(`Cleared cache for ${clearedCount} presets`)
 		return clearedCount
 	} catch (error) {

--- a/src/lib/presetCache.ts
+++ b/src/lib/presetCache.ts
@@ -27,7 +27,7 @@ export async function getPresetContent(presetKey: string): Promise<string | null
 		// Check cache first
 		const cache = getCacheService()
 		const cacheKey = `preset:${presetKey}`
-
+		
 		try {
 			const cachedData = await cache.get(cacheKey)
 			if (cachedData) {
@@ -175,11 +175,11 @@ export async function clearPresetCache(presetKey: string): Promise<boolean> {
 		const cache = getCacheService()
 		const cacheKey = `preset:${presetKey}`
 		const success = await cache.delete(cacheKey)
-
+		
 		if (success) {
 			logAlways(`Cleared cache for preset ${presetKey}`)
 		}
-
+		
 		return success
 	} catch (error) {
 		logErrorAlways(`Error clearing cache for preset ${presetKey}:`, error)
@@ -195,7 +195,7 @@ export async function clearAllPresetCaches(): Promise<number> {
 		const cache = getCacheService()
 		const allPresetKeys = Object.keys(presets)
 		let clearedCount = 0
-
+		
 		for (const presetKey of allPresetKeys) {
 			const cacheKey = `preset:${presetKey}`
 			const success = await cache.delete(cacheKey)
@@ -203,7 +203,7 @@ export async function clearAllPresetCaches(): Promise<number> {
 				clearedCount++
 			}
 		}
-
+		
 		logAlways(`Cleared cache for ${clearedCount} presets`)
 		return clearedCount
 	} catch (error) {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -6,7 +6,8 @@
 	const endpoints = {
 		sync: '/api/sync-content',
 		'update-distilled': '/api/update-distilled',
-		'heap-snapshot': '/api/heap-snapshot'
+		'heap-snapshot': '/api/heap-snapshot',
+		'memory-status': '/api/memory-status'
 	}
 
 	// Load secret key from localStorage on mount
@@ -127,6 +128,12 @@
 				<span class="method">GET</span>
 				<a href="/api/scheduler-status">/api/scheduler-status</a>
 				<span class="description">Check background scheduler status</span>
+			</div>
+
+			<div class="endpoint">
+				<span class="method">GET</span>
+				<a href="/api/memory-status">/api/memory-status</a>
+				<span class="description">View current memory usage and system statistics</span>
 			</div>
 
 			<div class="endpoint" class:disabled={!secretKey.trim()}>

--- a/src/routes/api/heap-snapshot/+server.ts
+++ b/src/routes/api/heap-snapshot/+server.ts
@@ -24,7 +24,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
 	try {
 		// Use different output directories for dev vs production
-		const outputDir = dev ? './mount' : '/app/outputs'
+		const outputDir = dev || env.DEV === 'true' ? './mount' : '/app/outputs'
 
 		if (!existsSync(outputDir)) {
 			logAlways('Creating outputs directory:', outputDir)

--- a/src/routes/api/memory-status/+server.ts
+++ b/src/routes/api/memory-status/+server.ts
@@ -1,0 +1,124 @@
+import { json, error } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+import { logAlways } from '$lib/log'
+
+export const GET: RequestHandler = async () => {
+	try {
+		const memUsage = process.memoryUsage()
+		
+		// Get system memory info if available
+		let systemMemory = null
+		try {
+			const os = await import('node:os')
+			systemMemory = {
+				free: os.freemem(),
+				total: os.totalmem(),
+				freeFormatted: formatBytes(os.freemem()),
+				totalFormatted: formatBytes(os.totalmem()),
+				usedPercentage: ((os.totalmem() - os.freemem()) / os.totalmem() * 100).toFixed(1)
+			}
+		} catch (e) {
+			// System memory not available
+		}
+
+		// Get process uptime
+		const uptimeSeconds = process.uptime()
+		const uptime = {
+			seconds: uptimeSeconds,
+			formatted: formatUptime(uptimeSeconds)
+		}
+
+		// Get GC stats if available
+		let gcStats = null
+		try {
+			const v8 = await import('node:v8')
+			const stats = v8.getHeapStatistics()
+			gcStats = {
+				totalHeapSize: stats.total_heap_size,
+				totalHeapSizeExecutable: stats.total_heap_size_executable,
+				totalPhysicalSize: stats.total_physical_size,
+				totalAvailableSize: stats.total_available_size,
+				usedHeapSize: stats.used_heap_size,
+				heapSizeLimit: stats.heap_size_limit,
+				mallocedMemory: stats.malloced_memory,
+				peakMallocedMemory: stats.peak_malloced_memory,
+				doesZapGarbage: stats.does_zap_garbage,
+				numberOfNativeContexts: stats.number_of_native_contexts,
+				numberOfDetachedContexts: stats.number_of_detached_contexts
+			}
+		} catch (e) {
+			// GC stats not available
+		}
+
+		const response = {
+			success: true,
+			timestamp: new Date().toISOString(),
+			process: {
+				pid: process.pid,
+				uptime,
+				memory: {
+					rss: memUsage.rss,
+					heapTotal: memUsage.heapTotal,
+					heapUsed: memUsage.heapUsed,
+					external: memUsage.external,
+					arrayBuffers: memUsage.arrayBuffers,
+					// Formatted versions
+					rssFormatted: formatBytes(memUsage.rss),
+					heapTotalFormatted: formatBytes(memUsage.heapTotal),
+					heapUsedFormatted: formatBytes(memUsage.heapUsed),
+					externalFormatted: formatBytes(memUsage.external),
+					arrayBuffersFormatted: formatBytes(memUsage.arrayBuffers),
+					// Heap usage percentage
+					heapUsagePercentage: (memUsage.heapUsed / memUsage.heapTotal * 100).toFixed(1)
+				}
+			},
+			system: systemMemory,
+			v8: gcStats
+		}
+
+		logAlways('Memory status requested:', {
+			heapUsed: memUsage.heapUsed,
+			heapTotal: memUsage.heapTotal,
+			rss: memUsage.rss,
+			uptime: uptimeSeconds
+		})
+
+		return json(response)
+	} catch (e) {
+		throw error(
+			500,
+			`Failed to get memory status: ${e instanceof Error ? e.message : String(e)}`
+		)
+	}
+}
+
+/**
+ * Format bytes into human readable format
+ */
+function formatBytes(bytes: number): string {
+	if (bytes === 0) return '0 B'
+
+	const k = 1024
+	const sizes = ['B', 'KB', 'MB', 'GB']
+	const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+/**
+ * Format uptime into human readable format
+ */
+function formatUptime(seconds: number): string {
+	const days = Math.floor(seconds / 86400)
+	const hours = Math.floor((seconds % 86400) / 3600)
+	const minutes = Math.floor((seconds % 3600) / 60)
+	const secs = Math.floor(seconds % 60)
+
+	const parts = []
+	if (days > 0) parts.push(`${days}d`)
+	if (hours > 0) parts.push(`${hours}h`)
+	if (minutes > 0) parts.push(`${minutes}m`)
+	if (secs > 0 || parts.length === 0) parts.push(`${secs}s`)
+
+	return parts.join(' ')
+}

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -71,7 +71,6 @@ const mockDistilledVersions = {
 
 // Complete mock data object that matches the new PageData type
 const mockPageData = {
-	isOldHost: false,
 	presetSizes: mockPresetSizes,
 	distilledVersions: mockDistilledVersions
 }
@@ -135,7 +134,6 @@ describe('/+page.svelte', () => {
 	test('should handle failed distilled versions API calls gracefully', async () => {
 		// Create mock data with failed promises
 		const mockPageDataWithFailures = {
-			isOldHost: false,
 			presetSizes: mockPresetSizes,
 			distilledVersions: {
 				...mockDistilledVersions,

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -4,7 +4,6 @@
 		"verbatimModuleSyntax": false,
 		"isolatedModules": false,
 		"useUnknownInCatchVariables": false,
-		"skipLibCheck": true,
-		"noImplicitAny": false
+		"skipLibCheck": true
 	}
 }


### PR DESCRIPTION
  - Switch from GitHub tarball override back to published npm
  version 0.0.0-1c08e814-20250813181123
  - Add comprehensive stress testing script with MCP session
  management
  - Add memory status API endpoint with heap and system
  metrics
  - Add development scripts for build profiling and heap
  snapshots
  - Remove TypeScript linting overrides and restore stricter
  checking
  - Update admin panel with memory monitoring endpoints
  - Fix MCP handler imports and simplify type annotations
  - Clean up test mocks and TypeScript configuration